### PR TITLE
Enhance OSX notifications

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -7,18 +7,18 @@ from typing import List
 import tarfile
 
 
-def backup_notify(user_os, backup_path):
+def backup_notify(user_os, backup_path, number_of_files, backup_size):
     if user_os == "Linux":
         subprocess.Popen(["notify-send", f"Backed up!"])
         # Open the file explorer to the backed up directory
         subprocess.run(["xdg-open", backup_path])
     elif user_os == "macOS":
         subprocess.call(
-            (
-                "/usr/bin/osascript",
+            [
+                "osascript",
                 "-e",
-                'display notification "Backup of Kobo complete" with title "KoboBackup"',
-            )
+                f'display notification "Copied {number_of_files} files with a size of {backup_size} to {backup_path}." with title "Kobo Backup Complete"',
+            ]
         )
 
 


### PR DESCRIPTION
This PR adds additional features to the notifications function including now providing the backup size, number of files and backup path. The OSX notification has been updated to include this new information. Have also fixed a bug with reporting on backup size on first backup as reported in #24.